### PR TITLE
📁 ▸ Adding the GameSystems folder (check desc)

### DIFF
--- a/GameFiles/Loot-Saloon/Assets/GameSystems.meta
+++ b/GameFiles/Loot-Saloon/Assets/GameSystems.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3833f2cded32f05429f35ee9d925484f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This folder is now empty, because we can't move all the wanted folders inside it because other devs are working on it.

That means in the futur when a feature will be finished, that feature folder should be moved inside the GameSystems folder.